### PR TITLE
Add request cache policy

### DIFF
--- a/Sources/Squid/Request/Request.swift
+++ b/Sources/Squid/Request/Request.swift
@@ -32,6 +32,11 @@ public protocol Request: NetworkRequest {
     /// `HttpData.Empty` is returned.
     var body: HttpBody { get }
 
+    /// The value that indicates should service cached this specific request. This property used by
+    /// `CachingServiceHook` by default, but you also able to consider this value in your implementation
+    /// of the caching service hook
+    var shouldCacheResult: Bool { get }
+    
     /// Prepares the URL request that will be sent. The function is passed the request as assembled
     /// based on all other properties. You may modify the request as you wish.
     ///
@@ -88,6 +93,11 @@ extension Request {
     /// By default, all 2xx status codes are accepted.
     public var acceptedStatusCodes: CountableClosedRange<Int> {
         return 200...299
+    }
+    
+    /// By default, all results are cached.
+    public var shouldCacheResult: Bool {
+        return true
     }
 
     // MARK: Scheduling Requests

--- a/Sources/Squid/Service/Hooks/CachingServiceHook.swift
+++ b/Sources/Squid/Service/Hooks/CachingServiceHook.swift
@@ -30,6 +30,9 @@ public class CachingServiceHook: ServiceHook {
     public func onSchedule<R>(
         _ request: R, _ urlRequest: URLRequest
     ) -> R.Result? where R: Request {
+        guard request.shouldCacheResult else {
+            return nil
+        }
         guard request.method == .get else {
             return nil
         }
@@ -47,6 +50,9 @@ public class CachingServiceHook: ServiceHook {
     public func onSuccess<R>(
         _ request: R, _ urlRequest: URLRequest, result: R.Result
     ) where R: Request {
+        guard request.shouldCacheResult else {
+            return
+        }
         guard request.method == .get else {
             return
         }

--- a/Tests/SquidTests/Utils/Requests.swift
+++ b/Tests/SquidTests/Utils/Requests.swift
@@ -17,6 +17,19 @@ struct UsersRequest: JsonRequest {
     }
 }
 
+struct NotCachableUsersRequest: JsonRequest {
+    
+    typealias Result = [UserContainer]
+    
+    var routes: HttpRoute {
+        return ["users"]
+    }
+    
+    var shouldCacheResult: Bool {
+        return false
+    }
+}
+
 struct AuthorizeRequest: Request {
     
     typealias Result = Void


### PR DESCRIPTION
## Idea
Sometimes it is wise not to cache some requests that belong to the same HttpService. It's not possible right now, and as a result, you must create multiply HttpServices with cache hook and without. The idea is that let request decide if the response should be cached.

## Solution
Add a new property for the `Request` protocol, which is then used by the cache hook to determine if the response should be cached. For example:

``` swift
struct SomeRequest: JsonRequest {
    ...
    var shouldCacheResult: Bool {
        return false
    }
    ...
}
```

This property will be used in default `CachingServiceHook`, but you are also free to use this property in your cache-layer implementation