### PR TITLE
Support per-request base URLs

### DIFF
--- a/Sources/Squid/Core/Combine/Delegate/Delegates.swift
+++ b/Sources/Squid/Core/Combine/Delegate/Delegates.swift
@@ -7,13 +7,13 @@
 
 import Foundation
 
-internal protocol HttpTaskSubscriptionDelegate: class {
+internal protocol HttpTaskSubscriptionDelegate: AnyObject {
 
     func receive(_ data: Data)
     func finalize(response: URLResponse?, error: Error?)
 }
 
-internal protocol WSTaskSubscriptionDelegate: class {
+internal protocol WSTaskSubscriptionDelegate: AnyObject {
 
     func close(with error: URLSessionWebSocketTask.CloseCode, reason: Data?)
 }

--- a/Sources/Squid/Core/Request/HttpRequest.swift
+++ b/Sources/Squid/Core/Request/HttpRequest.swift
@@ -99,13 +99,16 @@ extension HttpRequest {
             .mapError(Squid.Error.ensure(_:))
             .flatMap { header -> Future<HttpRequest, Squid.Error> in
                 return .init { promise in
-                    // 1) Initialize request with destination URL
-                    guard var httpRequest = HttpRequest(url: service.apiUrl) else {
+                    // 1) Determine destination url
+                    let url = request.url ?? service.apiUrl
+
+                    // 2) Initialize request with destination URL
+                    guard var httpRequest = HttpRequest(url: url) else {
                         promise(.failure(.invalidUrl))
                         return
                     }
 
-                    // 2) Modify request to carry all required data
+                    // 3) Modify request to carry all required data
                     do {
                         let secure = request.usesSecureProtocol ?? service.usesSecureProtocol
                         httpRequest = try httpRequest
@@ -120,7 +123,7 @@ extension HttpRequest {
                         promise(.failure(.ensure(error)))
                     }
 
-                    // 3) Validate request
+                    // 4) Validate request
                     if let error = request.validate() {
                         promise(.failure(error))
                     }
@@ -137,13 +140,16 @@ extension HttpRequest {
             .mapError(Squid.Error.ensure(_:))
             .flatMap { header -> Future<HttpRequest, Squid.Error> in
                 return .init { promise in
-                    // 1) Initialize request with destination URL
-                    guard var httpRequest = HttpRequest(url: service.apiUrl) else {
+                    // 1) Determine destination url
+                    let url = request.url ?? service.apiUrl
+
+                    // 2) Initialize request with destination URL
+                    guard var httpRequest = HttpRequest(url: url) else {
                         promise(.failure(.invalidUrl))
                         return
                     }
 
-                    // 2) Modify request to carry all required data
+                    // 3) Modify request to carry all required data
                     do {
                         let secure = request.usesSecureProtocol ?? service.usesSecureProtocol
                         httpRequest = try httpRequest

--- a/Sources/Squid/Request/AnyRequest.swift
+++ b/Sources/Squid/Request/AnyRequest.swift
@@ -28,6 +28,7 @@ public struct AnyRequest<S: HttpService>: Request {
     // MARK: Properties
     private let service: S
 
+    public let url: UrlConvertible?
     public let routes: HttpRoute
 
     public let method: HttpMethod
@@ -56,6 +57,7 @@ public struct AnyRequest<S: HttpService>: Request {
                 query: HttpQuery = [:],
                 header: HttpHeader = [:],
                 body: HttpBody = HttpData.Empty(),
+                url: UrlConvertible? = nil,
                 acceptedStatusCodes: CountableClosedRange<Int> = 200...299,
                 priority: RequestPriority = .default,
                 service: S) {
@@ -65,6 +67,7 @@ public struct AnyRequest<S: HttpService>: Request {
         self.query = query
         self.header = header
         self.body = body
+        self.url = url
         self.acceptedStatusCodes = acceptedStatusCodes
         self.priority = priority
     }

--- a/Sources/Squid/Request/NetworkRequest.swift
+++ b/Sources/Squid/Request/NetworkRequest.swift
@@ -19,6 +19,10 @@ public protocol NetworkRequest {
     var usesSecureProtocol: Bool? { get }
 
     // MARK: URL Manipulation
+    /// The optional base URL of the API endpoint represented by this HTTP request (e.g. "api.example.com").
+    /// If this option is set, it overrides the `apiUrl` option set on the service it is scheduled against.
+    var url: UrlConvertible? { get }
+
     /// The routing paths of the request.
     var routes: HttpRoute { get }
 
@@ -42,6 +46,11 @@ extension NetworkRequest {
     /// By default, this is set to `true`. Think twice before setting this to `false` and allowing
     /// insecure network requests.
     public var usesSecureProtocol: Bool? {
+        return nil
+    }
+
+    /// By default, the apiUrl on the service is used.
+    public var url: UrlConvertible? {
         return nil
     }
 

--- a/Sources/Squid/Service/HttpService.swift
+++ b/Sources/Squid/Service/HttpService.swift
@@ -20,7 +20,7 @@ public protocol HttpService {
     associatedtype RequestError: Error = Squid.Error
 
     // MARK: API Configuration
-    /// The URL of the API representes by this HTTP service (e.g. "api.example.com"). This is the
+    /// The URL of the API represented by this HTTP service (e.g. "api.example.com"). This is the
     /// only field that needs to be provided by a particular implementation. This url should not
     /// contain the scheme (e.g. "https://") as it might get overwritten unexpectedly by a request.
     var apiUrl: UrlConvertible { get }

--- a/Sources/Squid/StreamRequest/AnyStreamRequest.swift
+++ b/Sources/Squid/StreamRequest/AnyStreamRequest.swift
@@ -20,6 +20,7 @@ public struct AnyStreamRequest<ServiceType: HttpService>: StreamRequest {
     // MARK: Properties
     private let service: ServiceType
 
+    public let url: UrlConvertible?
     public let routes: HttpRoute
     public let query: HttpQuery
     public let priority: RequestPriority
@@ -34,11 +35,13 @@ public struct AnyStreamRequest<ServiceType: HttpService>: StreamRequest {
     /// - Parameter service: The service representing an API.
     public init(routes: HttpRoute,
                 query: HttpQuery = [:],
+                url: UrlConvertible? = nil,
                 priority: RequestPriority = .default,
                 service: ServiceType) {
         self.service = service
         self.routes = []
         self.query = query
+        self.url = url
         self.priority = priority
     }
 

--- a/Tests/SquidTests/Utils/Stub.swift
+++ b/Tests/SquidTests/Utils/Stub.swift
@@ -57,7 +57,10 @@ class StubFactory {
     
     func usersPost() {
         let descriptor = stub(condition: { request -> Bool in
-            let data = request.ohhttpStubs_httpBody!
+            guard let data = request.ohhttpStubs_httpBody else {
+                return false
+            }
+            
             let json = try! JSONSerialization.jsonObject(
                 with: data, options: []
             ) as! [String: String]


### PR DESCRIPTION
Up until now, one was able to define the base url of a request on the service only. If, for whatever reason, the base url for one of the requests is only given at run-time and is absolute, the `apiUrl` defined on the service has to be removed, which is cumbersome and boilerplate code. Instead, it should be possible to define the full URL on the requests itself, taking precedence over the `apiUrl` defined on the service. This PR adds this functionality to Squid.

Additionally, this PR adds conformance to the UrlConvertible protocol to Optional and Array types.

Furthermore, the deprecated `class` conformance of both `HttpTaskSubscriptionDelegate` and `WSTaskSubscriptionDelegate` was replaced by `AnyObject`, as suggested [here](https://docs.swift.org/swift-book/LanguageGuide/Protocols.html#ID281).